### PR TITLE
updating dogapi to 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/gshackles/hubot-datadog-snapshot#readme",
   "dependencies": {
     "coffee-script": "^1.10.0",
-    "dogapi": "^1.1.0"
+    "dogapi": "^2.8.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Hello,

This PR updates dogapi to 2.8.0, so new endpoints can be used (for example, the [embeds api](https://docs.datadoghq.com/api/#embeds)).

Any thoughts? 

Thanks :)